### PR TITLE
User endpoints

### DIFF
--- a/apps/backend/api/index.ts
+++ b/apps/backend/api/index.ts
@@ -8,6 +8,7 @@ import obsRoutes from '../routes/obsRoutes.js';
 import snapshotRoutes from '../routes/snapshotRoutes.js';
 import plantRoutes from '../routes/plantRoutes.js';
 import filterRoutes from '../routes/filterRoutes.js';
+import userRoutes from '../routes/userRoutes.js';
 
 dotenv.config();
 
@@ -63,6 +64,7 @@ app.use('/get-observation', getObsRoutes);
 app.use('/filter', filterRoutes);
 app.use('/snapshot', snapshotRoutes);
 app.use('/plants', plantRoutes);
+app.use('/users', userRoutes);
 
 app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });

--- a/apps/backend/controllers/authController.ts
+++ b/apps/backend/controllers/authController.ts
@@ -139,7 +139,7 @@ export async function getMe(req: Request, res: Response): Promise<void> {
 
     const { data: userData, error: dbError } = await supabase
       .from('users')
-      .select('id, username, email, firstname, lastname')
+      .select('userID, username, email, firstname, lastname, role')
       .eq('email', user.email)
       .single();
 
@@ -162,8 +162,14 @@ export async function getMe(req: Request, res: Response): Promise<void> {
 }
 
 export async function logout(_req: Request, res: Response): Promise<void> {
-  res.clearCookie('session');
   await supabase.auth.signOut();
+  // Matching the cookie options from the login endpoint
+  res.clearCookie('session', {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'strict',
+    path: '/',
+  });
   res.json({ message: 'Logged out successfully' });
 }
 

--- a/apps/backend/controllers/userController.ts
+++ b/apps/backend/controllers/userController.ts
@@ -1,0 +1,107 @@
+import { Request, Response } from 'express';
+import supabase from '../config/supabase.js';
+//import { getMe } from './authController.js';
+
+export async function getUserByID(req: Request, res: Response): Promise<void> {
+    try {
+        const userID = req.params.userid;
+
+        if (!userID) {
+            res.status(400).json({ error: "Missing userID in path params" });
+            return;
+        }
+
+        const {data: user, error } = await supabase
+            .from('users')
+            .select('userID, email, username, firstname, lastname, role')
+            .eq('userID', userID)
+            .single();
+        
+        if (error) {
+            res.status(400).json({ error: `Supabase error: ${error.message}` });
+            return;
+        }
+
+        if (!user) {
+            res.status(400).json({ error: "No user found" });
+        }
+
+        res.status(200).json(user)
+
+    } catch(error) {
+        res.status(500).json({ error: `Internal server error: ${error}` });
+    }
+}
+
+export async function getUserByEmail(req: Request, res: Response): Promise<void> {
+    try {
+        const email = req.params.email;
+
+        if (!email) {
+            res.status(400).json({ error: 'Missing user email' });
+            return;
+        }
+        
+        const { data: user, error} = await supabase
+            .from('users')
+            .select('userID, email, username, firstname, lastname, role')
+            .eq('email', email)
+            .single();
+
+        if (error) {
+            res.status(400).json({ error: `Supabase error: ${error.message}` });
+            return;
+        }
+
+        if (!user) {
+            res.status(400).json({ error: 'No user found' });
+            return;
+        }
+
+        res.status(200).json(user);
+
+    } catch(error) {
+        res.status(500).json({ error: `Internal server error: ${error}` });
+    }
+}
+
+export async function updateUserPersonalInfo(req: Request, res: Response): Promise<void> {
+    try {
+        // make sure appropriate headers are present
+
+        // make sure userID is present
+
+        // make sure user is only updating their own information
+        //  This could be implicit in the endpoint structure...
+
+        // make supabase call
+
+        // check for errors
+
+        // return success
+
+    } catch(error) {
+        res.status(500).json({ error: `Internal server error: ${error}`});
+    } 
+}
+
+export async function updateUserRole(req: Request, res: Response): Promise<void> {
+    try {
+        // make sure appropriate role header is present
+
+        // query validRoles table to make sure it's valid // we could hardcode, but meh
+
+        // make sure we are updating a valid uuid
+
+        // make sure the user trying to do the updating is an owner or an admin
+        
+        // make supabase call
+
+        // check for errors
+
+        // return success
+        
+    } catch(error) {
+        res.status(500).json({ error: `Internal server error: ${error}`});
+    }
+}

--- a/apps/backend/controllers/userController.ts
+++ b/apps/backend/controllers/userController.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import supabase from '../config/supabase.js';
-//import { getMe } from './authController.js';
+import { UpdateUserBody } from '../types.js';
 
 export async function getUserByID(req: Request, res: Response): Promise<void> {
     try {
@@ -68,17 +68,59 @@ export async function getUserByEmail(req: Request, res: Response): Promise<void>
 export async function updateUserPersonalInfo(req: Request, res: Response): Promise<void> {
     try {
         // make sure appropriate headers are present
+        const { username, email, firstname, lastname } = req.body;
 
-        // make sure userID is present
+        const updates: UpdateUserBody = {};
 
-        // make sure user is only updating their own information
-        //  This could be implicit in the endpoint structure...
+        if (username !== undefined) updates.username = username;
+        if (email !== undefined) updates.email = email;
+        if (firstname !== undefined) updates.firstname = firstname;
+        if (lastname !== undefined) updates.lastname = lastname;
 
-        // make supabase call
+        if (Object.keys(updates).length === 0) {
+            res.status(400).json({ error: 'No fields provided to update' });
+            return;
+        }
 
-        // check for errors
+        // extract token
+        const token =
+        req.cookies?.session ||
+        req.headers.authorization?.split(' ')[1];
 
-        // return success
+        if (!token) {
+            res.status(401).json({ error: 'Not authenticated' });
+            return;
+        }
+
+        // fetch the user
+        const {
+            data: { user },
+            error: userError
+        } = await supabase.auth.getUser(token);
+
+        if (userError || !user) {
+            res.status(401).json({ error: 'Authentication failed' });
+            return;
+        }
+
+        // make supabase update call
+        const { data: userData, error } = await supabase
+            .from('users')
+            .update(updates)
+            .eq('userID', user.id)
+            .select()
+            .single(); 
+
+        if (error) {
+            res.status(400).json({ error: `Supabase error: ${error.message}` });
+            return;
+        }
+
+        if (!userData) {
+            res.status(400).json({ error: 'No user data found to update' });
+        }
+
+        res.status(200).json({ message: `User updated successfully.` });
 
     } catch(error) {
         res.status(500).json({ error: `Internal server error: ${error}`});
@@ -87,19 +129,125 @@ export async function updateUserPersonalInfo(req: Request, res: Response): Promi
 
 export async function updateUserRole(req: Request, res: Response): Promise<void> {
     try {
-        // make sure appropriate role header is present
+        // make sure appropriate role header and email param present
+        const { role } = req.body;
+        const { email } = req.params;
 
-        // query validRoles table to make sure it's valid // we could hardcode, but meh
+        if (!role) {
+            res.status(400).json({ error: 'Missing required role header' });
+            return;
+        }
 
-        // make sure we are updating a valid uuid
+        if (!email) {
+            res.status(400).json({ error: 'Missing email in path parameters'});
+            return;
+        }
+
+        // query validRoles table to make sure it's valid 
+        // we could hardcode this but I'm trying to think modularly
+        const { data: roleData, error: roleError } = await supabase
+            .from('ValidRoles')
+            .select()
+            .eq('role', role)
+            .single();
+        
+        if (roleError) {
+            res.status(400).json({ error: `Supabase error: ${roleError.message}` });
+        }
+
+        if (!roleData) {
+            res.status(400).json({ error: 'Invalid role type' });
+        }
 
         // make sure the user trying to do the updating is an owner or an admin
-        
+        // extract token from cookies or auth header
+        const token =
+          req.cookies?.session ||
+          req.headers.authorization?.split(' ')[1];
+
+        if (!token) {
+            res.status(401).json({ error: 'Not authenticated' });
+            return;
+        }
+
+        // fetch the updater user from auth
+        const { data: { user } , error: authError } = await supabase.auth.getUser(token);
+
+        if (authError || !user) {
+            res.status(401).json({ error: 'Authentication failed' });
+            return;
+        }
+
+        // fetch the updater details from the users table using the auth user's id
+        const { data: updaterData, error: updaterTableError } = await supabase
+            .from('users')
+            .select('role')
+            .eq('userID', user.id)
+            .single();
+
+        if (updaterTableError || !updaterData) {
+            res.status(401).json({ error: 'Failed to retrieve updater user details' });
+            return;
+        }
+        const updater = { ...user, ...updaterData };
+
+        // updater must be either owner or admin
+        const allowedUpdaterRoles = ['owner', 'admin'];
+
+        if (!allowedUpdaterRoles.includes(updater.role)) {
+            res.status(403).json({ error: 'Insufficient authority to update roles' });
+            return;
+        }
+
+        // fetch the target user's current role using their email
+        const { data: targetUser, error: targetUserError } = await supabase
+            .from('users')
+            .select('role')
+            .eq('email', email)
+            .single();
+
+        if (targetUserError || !targetUser) {
+            res.status(400).json({ error: 'Target user not found' });
+            return;
+        }
+
+        // make sure the user's current and new roles are both below updater's authority level
+        // define a simple hierarchy: owner (3) > admin (2) > user (1)
+        const roleHierarchy: Record<string, number> = {
+            owner: 3,
+            admin: 2,
+            user: 1
+        };
+
+        const updaterAuthority = roleHierarchy[updater.role] ?? 0;
+        const targetCurrentAuthority = roleHierarchy[targetUser.role] ?? 0;
+        const newRoleAuthority = roleHierarchy[role as string] ?? 0;
+
+        // one nice thing about this is that it also prevents users from updating their own role.
+        // your role == your role, so no updating it.
+        if (updaterAuthority <= targetCurrentAuthority || updaterAuthority <= newRoleAuthority) {
+            res.status(403).json({ error: 'Insufficient authority to update the user role' });
+            return;
+        }
+
         // make supabase call
+        const { data: updateData, error: updateError } = await supabase
+            .from('users')
+            .update({ role: role })
+            .eq('email', email)
+            .select()
+            .single();
 
-        // check for errors
+        if (updateError) {
+            res.status(400).json({ error: `Supabase erorr: ${updateError.message}`});
+            return;
+        }
 
-        // return success
+        if (!updateData) {
+            res.status(400).json({ error: 'No user data returned'})
+        }
+
+        res.status(200).json({ message: 'User role updated successfully' });
         
     } catch(error) {
         res.status(500).json({ error: `Internal server error: ${error}`});

--- a/apps/backend/routes/userRoutes.ts
+++ b/apps/backend/routes/userRoutes.ts
@@ -1,0 +1,12 @@
+import express, { Router } from 'express';
+import * as userController from '../controllers/userController.js';
+import authMiddleware from '../middleware/authMiddleware.js';
+
+const userRoutes: Router = express.Router();
+
+userRoutes.get('/id/:userid', authMiddleware, userController.getUserByID);
+userRoutes.get('/email/:email', authMiddleware, userController.getUserByEmail);
+// userRoutes.put('/info', authMiddleware, userController.updateUserPersonalInfo);
+// userRoutes.put('/role/:userID', authMiddleware, userController.updateUserRole);
+
+export default userRoutes;

--- a/apps/backend/routes/userRoutes.ts
+++ b/apps/backend/routes/userRoutes.ts
@@ -6,7 +6,7 @@ const userRoutes: Router = express.Router();
 
 userRoutes.get('/id/:userid', authMiddleware, userController.getUserByID);
 userRoutes.get('/email/:email', authMiddleware, userController.getUserByEmail);
-// userRoutes.put('/info', authMiddleware, userController.updateUserPersonalInfo);
-// userRoutes.put('/role/:userID', authMiddleware, userController.updateUserRole);
+userRoutes.put('/info', authMiddleware, userController.updateUserPersonalInfo);
+userRoutes.put('/role/:email', authMiddleware, userController.updateUserRole);
 
 export default userRoutes;

--- a/apps/backend/types.ts
+++ b/apps/backend/types.ts
@@ -12,6 +12,7 @@ export interface UserData {
   email: string;
   firstname: string | null;
   lastname: string | null;
+  role: string;
 }
 
 export interface SignupBody {
@@ -103,4 +104,11 @@ export interface UpdatePlantBody {
   plantScientificName?: string;
   isNative?: boolean;
   subcategory?: string;
+}
+
+export interface UpdateUserBody {
+  username?: string;
+  email?: string;
+  firstname?: string;
+  lastname?: string;
 }

--- a/apps/frontend/types/auth.ts
+++ b/apps/frontend/types/auth.ts
@@ -12,6 +12,7 @@ export interface User {
   email: string;
   firstname?: string;
   lastname?: string;
+  role: string;
 }
 
 export interface UserContextType {


### PR DESCRIPTION
Added four endpoints for getting and manipulating user information from the users table.

`GET users/id/:userid`
- Gets a row from the users table by userID

`GET users/email/:email`
- Gets a row from the users table by email

`PUT users/info`
- Allows a user to update their own information, including email, username, firstname, and lastname. Does not allow updating
role.

`PUT users/role/:email`
- Allows admins and owners to update other user's roles by specifying an email, adhering to constraints specified in our spec.