### PR TITLE
when updating a user role, erase any roles they requested

### DIFF
--- a/apps/backend/controllers/userController.ts
+++ b/apps/backend/controllers/userController.ts
@@ -233,7 +233,7 @@ export async function updateUserRole(req: Request, res: Response): Promise<void>
         // make supabase call
         const { data: updateData, error: updateError } = await supabase
             .from('users')
-            .update({ role: role })
+            .update({ role: role, roleRequested: null }) // also erase any requested roles
             .eq('email', email)
             .select()
             .single();


### PR DESCRIPTION
Just adding something to handle the `roleRequested` field in the `users` table when updating user roles. When successfully updating a user role, we also set anything they requested to null because hitting the endpoint is a result of either approving their role request, denying it, or assigning another role regardless of what they asked for.